### PR TITLE
Improved hsm view

### DIFF
--- a/src/metadata_inspector/__init__.py
+++ b/src/metadata_inspector/__init__.py
@@ -194,7 +194,7 @@ def main(input_files: list[Path], html: bool = False) -> tuple[str, TextIO]:
             msg = f"{error_header}\n{error_msg}"
             return msg, sys.stderr
     if dset.nbytes == 0:
-        fsize = "unkown"
+        fsize = dset.attrs.pop("file_size", "unkown")
     else:
         fsize = size(dset.nbytes, system=alternative)
     if html:
@@ -212,7 +212,7 @@ def main(input_files: list[Path], html: bool = False) -> tuple[str, TextIO]:
         )
         out_str = xr.core.formatting.dataset_repr(dset)
     replace_str = (
-        ("xarray.Dataset", f"Dataset (byte-size: {fsize})"),
+        ("xarray.Dataset", f"Dataset (dataset-size: {fsize})"),
         (
             "<svg class='icon xr-icon-file-text2'>",
             "<i class='fa fa-file-text-o'>",

--- a/src/metadata_inspector/__init__.py
+++ b/src/metadata_inspector/__init__.py
@@ -72,7 +72,6 @@ def parse_args(args: Optional[list[str]] = None) -> tuple[list[Path], bool]:
 
 def dataset_from_hsm(input_file: str) -> xr.Dataset:
     """Create a dataset view from attributes."""
-    print(input_file)
     global_attrs: dict[str, dict[str, str]] = get_slk_metadata(input_file)
     attrs = json.loads(global_attrs.pop("document", {}).pop("Keywords", "{}"))
     nc_attrs = {}
@@ -171,7 +170,7 @@ def main(input_files: list[Path], html: bool = False) -> tuple[str, TextIO]:
     html: bool, default: True
         If true a representation suitable for html is displayed.
     """
-
+    xr.core.formatting.EMPTY_REPR = "    *not enough information for display*"
     files_fs, files_hsm = _get_files(input_files)
     if not files_fs and not files_hsm:
         return "No files found", sys.stderr

--- a/src/metadata_inspector/__init__.py
+++ b/src/metadata_inspector/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 from functools import partial
 from pathlib import Path
+import json
 import warnings
 import sys
 from typing import Optional, TextIO
@@ -12,7 +13,6 @@ from dask import array as dask_array
 from hurry.filesize import alternative, size
 import numpy as np
 import xarray as xr
-import yaml
 
 from ._version import __version__
 from ._slk import get_slk_metadata, login
@@ -72,13 +72,15 @@ def parse_args(args: Optional[list[str]] = None) -> tuple[list[Path], bool]:
 
 def dataset_from_hsm(input_file: str) -> xr.Dataset:
     """Create a dataset view from attributes."""
-
-    attrs: dict[str, dict[str, str]] = (
-        yaml.safe_load(get_slk_metadata(input_file)) or {}
-    ).get("Keywords", {})
-
-    dset = xr.Dataset({}, attrs=attrs.pop("global"))
-    for dim in attrs.pop("dims"):
+    print(input_file)
+    global_attrs: dict[str, dict[str, str]] = get_slk_metadata(input_file)
+    attrs = json.loads(global_attrs.pop("document", {}).pop("Keywords", "{}"))
+    nc_attrs = {}
+    for key in ("netcdf", "netcdf_header"):
+        for k, value in global_attrs.get(key, {}).items():
+            nc_attrs[k] = value
+    dset = xr.Dataset({}, attrs=attrs.pop("global", {}) or nc_attrs)
+    for dim in attrs.pop("dims", []):
         size = int(attrs[dim].pop("size"))
         start, end = float(attrs[dim].pop("start")), float(
             attrs[dim].pop("end")
@@ -87,7 +89,7 @@ def dataset_from_hsm(input_file: str) -> xr.Dataset:
         if dim == "time":
             vec = num2date(vec, attrs[dim]["units"], attrs[dim]["calendar"])
         dset[dim] = xr.DataArray(vec, name=dim, dims=(dim,), attrs=attrs[dim])
-    for data_var in attrs.pop("data_vars"):
+    for data_var in attrs.pop("data_vars", []):
         dims = attrs[data_var].pop("dims")
         sizes = [dset[d].size for d in dims]
         dset[data_var] = xr.DataArray(
@@ -192,7 +194,10 @@ def main(input_files: list[Path], html: bool = False) -> tuple[str, TextIO]:
         else:
             msg = f"{error_header}\n{error_msg}"
             return msg, sys.stderr
-    fsize = size(dset.nbytes, system=alternative)
+    if dset.nbytes == 0:
+        fsize = "unkown"
+    else:
+        fsize = size(dset.nbytes, system=alternative)
     if html:
         out_str = xr.core.formatting_html.dataset_repr(dset)
     else:

--- a/src/metadata_inspector/_slk.py
+++ b/src/metadata_inspector/_slk.py
@@ -56,12 +56,45 @@ def load_module() -> dict[str, str]:
     return _env
 
 
+def get_file_size(input_path: Path) -> str:
+    """Extract the size of an object on the HSM store.
+
+    Parameters
+    ----------
+    input_path: Path
+        The path to the hsm ojbect
+
+    Returns
+    -------
+    str: A string representation of the size of the ojbect
+    """
+    command = ["slk", "list", str(input_path)]
+    try:
+        res = run(
+            command, env=load_module(), check=True, stdout=PIPE, stderr=PIPE
+        )
+    except SubprocessError as error:  # pragma: no cover
+        warnings.warn(
+            f"Error: could not get meta-data: {error}"
+        )  # pragma: no cover
+        return "unkown"  # pragma: no cover
+    try:
+        out = [
+            line
+            for line in res.stdout.decode().split("\n")
+            if input_path.name in line
+        ]
+        return out[0].split()[3]
+    except IndexError:  # pragma: no cover
+        return "unkown"  # pragma: no cover
+
+
 def get_slk_metadata(input_path: str) -> dict[str, dict[str, str]]:
     """Extract dataset metdata from path in the hsm.
 
     Parameters
     ----------
-    input_path: Path
+    input_path: str
         The hsm path the metdata is extracted from
 
 
@@ -90,6 +123,7 @@ def get_slk_metadata(input_path: str) -> dict[str, dict[str, str]]:
     # Since yaml needs could not handle this we have to add the ':' to the
     # keys manually.
     data: dict[str, dict[str, str]] = {}
+    data.setdefault("netcdf", {})
     for line in res.stdout.decode().split("\n"):
         if line.startswith("netcdf") or line.startswith("document"):
             main_key = line.strip()
@@ -101,6 +135,7 @@ def get_slk_metadata(input_path: str) -> dict[str, dict[str, str]]:
             data[main_key][current_key] = value.strip()
         elif line:
             data[main_key][current_key] += line.strip()
+    data["netcdf"]["file_size"] = get_file_size(Path(input_path))
     return data
 
 

--- a/src/metadata_inspector/tests/conftest.py
+++ b/src/metadata_inspector/tests/conftest.py
@@ -223,7 +223,7 @@ def run(command: list[str], **kwargs: Any) -> SubProcess:
     """Patch the subprocess.run command."""
 
     main_command, sub_cmd = command[0:2]
-    if main_command.startswith("slk"):
+    if main_command.startswith("slk_helpers"):
         suffix = Path(command[-1]).suffix
         if sub_cmd == "metadata":
             if suffix == ".tar":
@@ -233,8 +233,7 @@ def run(command: list[str], **kwargs: Any) -> SubProcess:
             else:
                 cmd = global_meta_data
         else:
-            file_n = Path(command[-1]).name
-            cmd = f"-rw-r--r--- k204230 bm0146  15M 16 Feb 2023 22:15 {file_n}"
+            cmd = "1535041\n"
         return SubProcess([cmd])
 
     return SubProcess(command, is_fake=False)

--- a/src/metadata_inspector/tests/conftest.py
+++ b/src/metadata_inspector/tests/conftest.py
@@ -223,7 +223,7 @@ def run(command: list[str], **kwargs: Any) -> SubProcess:
     """Patch the subprocess.run command."""
 
     main_command, sub_cmd = command[0:2]
-    if main_command.startswith("slk_helpers"):
+    if main_command.startswith("slk"):
         suffix = Path(command[-1]).suffix
         if sub_cmd == "metadata":
             if suffix == ".tar":
@@ -232,7 +232,11 @@ def run(command: list[str], **kwargs: Any) -> SubProcess:
                 cmd += "\n   Version: ae7677769b0a757248659ddbbb83f224"
             else:
                 cmd = global_meta_data
-            return SubProcess([cmd])
+        else:
+            file_n = Path(command[-1]).name
+            cmd = f"-rw-r--r--- k204230 bm0146  15M 16 Feb 2023 22:15 {file_n}"
+        return SubProcess([cmd])
+
     return SubProcess(command, is_fake=False)
 
 

--- a/src/metadata_inspector/tests/test_inspector.py
+++ b/src/metadata_inspector/tests/test_inspector.py
@@ -87,3 +87,4 @@ def test_hsm_without_key(patch_file: Path) -> None:
     from metadata_inspector import main
 
     out, text_io = main([Path("/arch/foo/bar.nc")])
+    assert "ua" in out

--- a/src/metadata_inspector/tests/test_inspector.py
+++ b/src/metadata_inspector/tests/test_inspector.py
@@ -75,9 +75,15 @@ def test_fileiter(netcdf_files: Path, patch_file: Path) -> None:
     assert out == nc_files
 
 
-def test_hsm(patch_file: Path) -> None:
+def test_hsm_with_key(patch_file: Path) -> None:
     """Test reading metadata from the hsm."""
     from metadata_inspector import main
 
     out, text_io = main([Path("/arch/foo/bar.tar")])
     assert "orog" in out
+
+
+def test_hsm_without_key(patch_file: Path) -> None:
+    from metadata_inspector import main
+
+    out, text_io = main([Path("/arch/foo/bar.nc")])

--- a/src/metadata_inspector/tests/test_slk.py
+++ b/src/metadata_inspector/tests/test_slk.py
@@ -1,0 +1,24 @@
+"""Test for the slk module."""
+
+import mock
+import os
+from pathlib import Path
+import shutil
+
+
+def test_load_module(slk_bin: Path) -> None:
+    """Testing the module load command."""
+    from metadata_inspector._slk import load_module, MODULES_CMD_ENV
+
+    env = os.environ.copy()
+    env[MODULES_CMD_ENV] = str(slk_bin)
+    mock_env = load_module()
+    assert mock_env == {}
+    with mock.patch.dict(os.environ, env, clear=True):
+        mock_env = load_module()
+        assert "PATH" in mock_env
+        assert shutil.which("slk", path=mock_env["PATH"]) is not None
+        assert shutil.which("slk_helpers", path=mock_env["PATH"]) is not None
+    with mock.patch.dict(os.environ, mock_env, clear=True):
+        tmp_env = load_module()
+        assert os.environ["PATH"] == mock_env["PATH"] == tmp_env["PATH"]


### PR DESCRIPTION
This does two things:

- It loads the slk module rather then using a fixed and outdated path to the slk binary
- It creates an (empty) xarray dataset only form the tags found in netcdf and netcdf_header metadata. Then at least some rudimentary overview of the meta-data can be displayed.

The output of a dataset that hasn't been tagged with the special string that is a json representation of the whole data set would look like this:

```
<Dataset>
Dimensions:  ()
Data variables:
    *empty*
Attributes: (12/50)
    Var_Long_Name:         time,Longitude,Latitude,pressure,Eastward Wind
    License:               CMIP6 model data produced by CSIRO is licensed und...
    Title:                 ACCESS-CM2 output prepared for CMIP6
    Var_Name:              time,time_bnds,lon,lon_bnds,lat,lat_bnds,plev,plev...
    Pid:                   hdl:21.14100/215c74d3-0509-4aca-8338-958b6c502eab
    Experiment_Id:         amip
    ...                    ...
    Parent_Experiment_Id:  no parent
    Activity_Id:           CMIP
    Frequency:             mon
    Sub_Experiment:        none
    Further_Info_Url:      https://furtherinfo.es-doc.org/CMIP6.CSIRO-ARCCSS....
    Variant_Label:         r1i1p1f1
```

I think I can't do really much more at the moment because essential information, like the dimensionality of the variables, are missing.

